### PR TITLE
bugfix: memory corrupted by ata disk read on buf1. buf1 is moved to global.

### DIFF
--- a/apps/shell.c
+++ b/apps/shell.c
@@ -283,6 +283,7 @@ static int command_test(char *args)
 static int command_shutdown(char *args)
 {
 	syscall(SYSCALL_SHUTDOWN, 0, 0, 0);
+	(void)args;
 	return 0;
 }
 

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -8,7 +8,7 @@ CFLAGS	+=	-Iinclude
 	gcc $(CFLAGS) -o $@ $<
 
 kernel.bin: sys.o cpu.o intr.o excp.o memory.o sched.o fs.o task.o syscall.o lock.o timer.o console_io.o queue.o common.o debug.o init.o kern_task_init.o \
-	 pci.o ata.o stdlib.o string.o block_driver.o
+	 pci.o ata.o stdlib.o string.o block_driver.o i825xx.o
 	ld -o $@ $+ -Map System.map -s -T sys.ld -x
 
 sys.o: sys.S
@@ -33,6 +33,7 @@ ata.o: ata.c
 stdlib.o: stdlib.c
 string.o: string.c
 block_driver.o: block_driver.c
+i825xx.o: i825xx.c
 
 clean:
 	rm -f *~ *.o *.bin *.dat *.img *.map

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -1,4 +1,4 @@
-CFLAGS	=	-Wall -Wextra
+CFLAGS	=	-Wall -Wextra -Wno-unused-function
 CFLAGS	+=	-nostdinc -nostdlib -fno-builtin -c
 CFLAGS	+=	-Iinclude
 

--- a/kernel/i825xx.c
+++ b/kernel/i825xx.c
@@ -1,0 +1,522 @@
+/*
+ * Copyright (c) 2011 Joshua Cornutt <jcornutt@randomaccessit.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <sys/types.h>
+#include <string.h>
+#include <stdlib.h>
+#include <io_port.h>
+#include <pci.h>
+#include <i825xx.h>
+#include <console_io.h>
+#include <memory.h>
+#include <timer.h>
+
+typedef struct CPUContext {
+ uint32_t vector;
+} CPUContext;
+
+typedef struct net_device_t {
+	uint32_t tx_count;
+	uint32_t rx_count;
+	uint32_t packets_dropped;
+	void* lldev;
+	uint32_t hwid;
+	uint8_t mac_address[6];
+	uint16_t interrupt_line;
+	struct pci_device *pci;
+	void (*rx_poll)(struct net_device_t *netdev);
+	void (*tx_poll)(struct net_device_t *netdev, void *pkt, uint16_t length );
+	void (*rx_init)(struct net_device_t *netdev);
+	void (*tx_init)(struct net_device_t *netdev);
+	void (*rx_enable)(struct net_device_t *netdev);
+} net_device_t;
+
+// MMIO operations
+static uint8_t mmio_read8 (uint32_t p_address);
+static uint16_t mmio_read16 (uint32_t p_address);
+static uint32_t mmio_read32 (uint32_t p_address);
+static uint64_t mmio_read64 (uint32_t p_address);
+static void mmio_write8 (uint32_t p_address,uint8_t p_value);
+static void mmio_write16 (uint32_t p_address,uint16_t p_value);
+static void mmio_write32 (uint32_t p_address,uint32_t p_value);
+static void mmio_write64 (uint32_t p_address,uint64_t p_value);
+
+uint8_t mmio_read8 (uint32_t p_address)
+{
+    return *((volatile uint8_t*)(p_address));
+}
+uint16_t mmio_read16 (uint32_t p_address)
+{
+    return *((volatile uint16_t*)(p_address));
+}
+uint32_t mmio_read32 (uint32_t p_address)
+{
+    return *((volatile uint32_t*)(p_address));
+}
+uint64_t mmio_read64 (uint32_t p_address)
+{
+    return *((volatile uint64_t*)(p_address));
+}
+void mmio_write8 (uint32_t p_address,uint8_t p_value)
+{
+    (*((volatile uint8_t*)(p_address)))=(p_value);
+}
+void mmio_write16 (uint32_t p_address,uint16_t p_value)
+{
+    (*((volatile uint16_t*)(p_address)))=(p_value);
+}
+void mmio_write32 (uint32_t p_address,uint32_t p_value)
+{
+    (*((volatile uint32_t*)(p_address)))=(p_value);
+}
+void mmio_write64 (uint32_t p_address,uint64_t p_value)
+{
+    (*((volatile uint64_t*)(p_address)))=(p_value);
+}
+
+
+#define NUM_RX_DESCRIPTORS	768
+#define NUM_TX_DESCRIPTORS	768
+
+#define CTRL_FD				(1 << 0)
+#define CTRL_ASDE			(1 << 5)
+#define CTRL_SLU			(1 << 6)
+
+// RX and TX descriptor structures
+typedef struct __attribute__((packed)) i825xx_rx_desc_s
+{
+	volatile uint64_t	address;
+
+	volatile uint16_t	length;
+	volatile uint16_t	checksum;
+	volatile uint8_t	status;
+	volatile uint8_t	errors;
+	volatile uint16_t	special;
+} i825xx_rx_desc_t;
+
+typedef struct __attribute__((packed)) i825xx_tx_desc_s
+{
+	volatile uint64_t	address;
+
+	volatile uint16_t	length;
+	volatile uint8_t	cso;
+	volatile uint8_t	cmd;
+	volatile uint8_t	sta;
+	volatile uint8_t	css;
+	volatile uint16_t	special;
+} i825xx_tx_desc_t;
+
+// Device-specific structure
+typedef struct i825xx_device_s
+{
+	uintptr_t	mmio_address;
+	uint32_t	io_address;
+
+	volatile uint8_t		*rx_desc_base;
+	volatile i825xx_rx_desc_t	*rx_desc[NUM_RX_DESCRIPTORS];	// receive descriptor buffer
+	volatile uint16_t	rx_tail;
+
+	volatile uint8_t		*tx_desc_base;
+	volatile i825xx_tx_desc_t	*tx_desc[NUM_TX_DESCRIPTORS];	// transmit descriptor buffer
+	volatile uint16_t	tx_tail;
+
+	uint16_t	(* eeprom_read)( struct i825xx_device_s *, uint8_t );
+} i825xx_device_t;
+
+static uint16_t net_i825xx_eeprom_read( i825xx_device_t *dev, uint8_t ADDR )
+{
+	uint16_t DATA = 0;
+	uint32_t tmp = 0;
+	mmio_write32( i825xx_REG_EERD, (1) | ((uint32_t)(ADDR) << 8) );
+
+	while( !((tmp = mmio_read32(i825xx_REG_EERD)) & (1 << 4)) )
+		timer_wait_loop_usec(1);
+
+	DATA = (uint16_t)((tmp >> 16) & 0xFFFF);
+	return DATA;
+}
+
+/****************************************************
+ ** Management Data Input/Output (MDI/O) Interface **
+ ** "This interface allows upper-layer devices to  **
+ **  monitor and control the state of the PHY."    **
+ ****************************************************/
+#define MDIC_PHYADD			(1 << 21)
+#define MDIC_OP_WRITE		(1 << 26)
+#define MDIC_OP_READ		(2 << 26)
+#define MDIC_R				(1 << 28)
+#define MDIC_I				(1 << 29)
+#define MDIC_E				(1 << 30)
+
+static uint16_t net_i825xx_phy_read( i825xx_device_t *dev, int MDIC_REGADD )
+{
+	uint16_t MDIC_DATA = 0;
+
+	mmio_write32( i825xx_REG_MDIC, (((MDIC_REGADD & 0x1F) << 16) |
+									MDIC_PHYADD | MDIC_I | MDIC_OP_READ) );
+
+	while( !(mmio_read32(i825xx_REG_MDIC) & (MDIC_R | MDIC_E)) )
+	{
+		timer_wait_loop_usec(1);
+	}
+
+	if( mmio_read32(i825xx_REG_MDIC) & MDIC_E )
+	{
+		printk("i825xx: MDI READ ERROR\n");
+		return -1;
+	}
+
+	MDIC_DATA = (uint16_t)(mmio_read32(i825xx_REG_MDIC) & 0xFFFF);
+	return MDIC_DATA;
+}
+
+static void net_i825xx_phy_write( i825xx_device_t *dev, int MDIC_REGADD, uint16_t MDIC_DATA )
+{
+	mmio_write32( i825xx_REG_MDIC, ((MDIC_DATA & 0xFFFF) | ((MDIC_REGADD & 0x1F) << 16) |
+									MDIC_PHYADD | MDIC_I | MDIC_OP_WRITE) );
+
+	while( !(mmio_read32(i825xx_REG_MDIC) & (MDIC_R | MDIC_E)) )
+	{
+		timer_wait_loop_usec(1);
+	}
+
+	if( mmio_read32(i825xx_REG_MDIC) & MDIC_E )
+	{
+		printk("i825xx: MDI WRITE ERROR\n");
+		return;
+	}
+}
+
+#define RCTL_EN				(1 << 1)
+#define RCTL_SBP			(1 << 2)
+#define RCTL_UPE			(1 << 3)
+#define RCTL_MPE			(1 << 4)
+#define RCTL_LPE			(1 << 5)
+#define RDMTS_HALF			(0 << 8)
+#define RDMTS_QUARTER		(1 << 8)
+#define RDMTS_EIGHTH		(2 << 8)
+#define RCTL_BAM			(1 << 15)
+#define RCTL_BSIZE_256		(3 << 16)
+#define RCTL_BSIZE_512		(2 << 16)
+#define RCTL_BSIZE_1024		(1 << 16)
+#define RCTL_BSIZE_2048		(0 << 16)
+#define RCTL_BSIZE_4096		((3 << 16) | (1 << 25))
+#define RCTL_BSIZE_8192		((2 << 16) | (1 << 25))
+#define RCTL_BSIZE_16384	((1 << 16) | (1 << 25))
+#define RCTL_SECRC			(1 << 26)
+
+static void net_i825xx_rx_enable( net_device_t *netdev )
+{
+	i825xx_device_t *dev = (i825xx_device_t *)netdev->lldev;
+	mmio_write32( i825xx_REG_RCTL, mmio_read32(i825xx_REG_RCTL) | (RCTL_EN) );
+}
+
+static int net_i825xx_rx_init( net_device_t *netdev )
+{
+	int i;
+	i825xx_device_t *dev = (i825xx_device_t *)netdev->lldev;
+
+	// unaligned base address
+	uint64_t tmpbase = (uint64_t)kmalloc((sizeof(i825xx_rx_desc_t) * NUM_RX_DESCRIPTORS) + 16);
+	// aligned base address
+	dev->rx_desc_base = (tmpbase % 16) ? (uint8_t *)((tmpbase) + 16 - (tmpbase % 16)) : (uint8_t *)tmpbase;
+
+	for( i = 0; i < NUM_RX_DESCRIPTORS; i++ )
+	{
+		dev->rx_desc[i] = (i825xx_rx_desc_t *)(dev->rx_desc_base + (i * 16));
+		dev->rx_desc[i]->address = (uint64_t)kmalloc(8192+16); // packet buffer size (8K)
+		dev->rx_desc[i]->status = 0;
+	}
+
+	// setup the receive descriptor ring buffer (TODO: >32-bits may be broken in this code)
+	mmio_write32( i825xx_REG_RDBAH, (uint32_t)((uint64_t)dev->rx_desc_base >> 32) );
+	mmio_write32( i825xx_REG_RDBAL, (uint32_t)((uint64_t)dev->rx_desc_base & 0xFFFFFFFF) );
+	printk("i825xx[%u]: RDBAH/RDBAL = %x:%x\n", netdev->hwid, mmio_read32(i825xx_REG_RDBAH), mmio_read32(i825xx_REG_RDBAL));
+
+	// receive buffer length; NUM_RX_DESCRIPTORS 16-byte descriptors
+	mmio_write32( i825xx_REG_RDLEN, (uint32_t)(NUM_RX_DESCRIPTORS * 16) );
+
+	// setup head and tail pointers
+	mmio_write32( i825xx_REG_RDH, 0 );
+	mmio_write32( i825xx_REG_RDT, NUM_RX_DESCRIPTORS );
+	dev->rx_tail = 0;
+
+	// set the receieve control register (promisc ON, 8K pkt size)
+	mmio_write32( i825xx_REG_RCTL, (RCTL_SBP | RCTL_UPE | RCTL_MPE | RDMTS_HALF | RCTL_SECRC |
+									RCTL_LPE | RCTL_BAM | RCTL_BSIZE_8192) );
+	return 0;
+}
+
+#define TCTL_EN				(1 << 1)
+#define TCTL_PSP			(1 << 3)
+
+static int net_i825xx_tx_init( net_device_t *netdev )
+{
+	int i;
+	i825xx_device_t *dev = (i825xx_device_t *)netdev->lldev;
+
+	uint64_t tmpbase = (uint64_t)kmalloc((sizeof(i825xx_tx_desc_t) * NUM_TX_DESCRIPTORS) + 16);
+	dev->tx_desc_base = (tmpbase % 16) ? (uint8_t *)((tmpbase) + 16 - (tmpbase % 16)) : (uint8_t *)tmpbase;
+
+	for( i = 0; i < NUM_TX_DESCRIPTORS; i++ )
+	{
+		dev->tx_desc[i] = (i825xx_tx_desc_t *)(dev->tx_desc_base + (i * 16));
+		dev->tx_desc[i]->address = 0;
+		dev->tx_desc[i]->cmd = 0;
+	}
+
+	// setup the transmit descriptor ring buffer
+	mmio_write32( i825xx_REG_TDBAH, (uint32_t)((uint64_t)dev->tx_desc_base >> 32) );
+	mmio_write32( i825xx_REG_TDBAL, (uint32_t)((uint64_t)dev->tx_desc_base & 0xFFFFFFFF) );
+	printk("i825xx[%u]: TDBAH/TDBAL = %x:%x\n", netdev->hwid, mmio_read32(i825xx_REG_TDBAH), mmio_read32(i825xx_REG_TDBAL));
+
+	// transmit buffer length; NUM_TX_DESCRIPTORS 16-byte descriptors
+	mmio_write32( i825xx_REG_TDLEN, (uint32_t)(NUM_TX_DESCRIPTORS * 16) );
+
+	// setup head and tail pointers
+	mmio_write32( i825xx_REG_TDH, 0 );
+	mmio_write32( i825xx_REG_TDT, NUM_TX_DESCRIPTORS );
+	dev->tx_tail = 0;
+
+	// set the transmit control register (padshortpackets)
+	mmio_write32( i825xx_REG_TCTL, (TCTL_EN | TCTL_PSP) );
+	return 0;
+}
+
+static void net_i825xx_tx_poll( net_device_t *netdev, void *pkt, uint16_t length )
+{
+	i825xx_device_t *dev = (i825xx_device_t *)netdev->lldev;
+	//printk("i825xx[%u]: transmitting packet (%u bytes) [h=%u, t=%u]\n", netdev->hwid, length, mmio_read32(i825xx_REG_TDH), dev->tx_tail);
+
+	dev->tx_desc[dev->tx_tail]->address = (uint64_t)pkt;
+	dev->tx_desc[dev->tx_tail]->length = length;
+	dev->tx_desc[dev->tx_tail]->cmd = ((1 << 3) | (3));
+
+	// update the tail so the hardware knows it's ready
+	int oldtail = dev->tx_tail;
+	dev->tx_tail = (dev->tx_tail + 1) % NUM_TX_DESCRIPTORS;
+	mmio_write32(i825xx_REG_TDT, dev->tx_tail);
+
+	while( !(dev->tx_desc[oldtail]->sta & 0xF) )
+	{
+		timer_wait_loop_usec(1);
+	}
+
+	netdev->tx_count++;
+	//printk("i825xx[%u]: transmit status = 0x%x\n", netdev->hwid, (dev->tx_desc[oldtail]->sta & 0xF));
+
+}
+
+// This can be used stand-alone or from an interrupt handler
+static void net_i825xx_rx_poll( net_device_t *netdev )
+{
+	i825xx_device_t *dev = (i825xx_device_t *)netdev->lldev;
+
+	while( (dev->rx_desc[dev->rx_tail]->status & (1 << 0)) )
+	{
+		// raw packet and packet length (excluding CRC)
+		uint8_t *pkt = (void *)dev->rx_desc[dev->rx_tail]->address;
+		uint16_t pktlen = dev->rx_desc[dev->rx_tail]->length;
+		bool dropflag = false;
+
+		if( pktlen < 60 )
+		{
+			printk("net[u]: short packet (%u bytes)\n", netdev->hwid, pktlen);
+			dropflag = true;
+		}
+
+		// while not technically an error, there is no support in this driver
+		if( !(dev->rx_desc[dev->rx_tail]->status & (1 << 1)) )
+		{
+			printk("net[%u]: no EOP set! (len=%u, 0x%x 0x%x 0x%x)\n",
+				netdev->hwid, pktlen, pkt[0], pkt[1], pkt[2]);
+			dropflag = true;
+		}
+
+		if( dev->rx_desc[dev->rx_tail]->errors )
+		{
+			printk("net[%u]: rx errors (0x%x)\n", netdev->hwid, dev->rx_desc[dev->rx_tail]->errors);
+			dropflag = true;
+		}
+
+		if( !dropflag )
+		{
+			// send the packet to higher layers for parsing
+		}
+
+		// update RX counts and the tail pointer
+		netdev->rx_count++;
+		dev->rx_desc[dev->rx_tail]->status = (uint16_t)(0);
+
+		dev->rx_tail = (dev->rx_tail + 1) % NUM_RX_DESCRIPTORS;
+
+		// write the tail to the device
+		mmio_write32(i825xx_REG_RDT, dev->rx_tail);
+	}
+}
+
+static void i825xx_interrupt_handler( CPUContext *ctx )
+{
+	net_device_t *netdev = find_net_device_by_irq( ctx->vector );
+	i825xx_device_t *dev = (i825xx_device_t *)netdev->lldev;
+
+	if( netdev == NULL )
+	{
+		printk("i825xx: UNKNOWN IRQ / INVALID DEVICE\n");
+		return;
+	}
+
+	// read the pending interrupt status
+	uint32_t icr = mmio_read32(dev->mmio_address + 0xC0);
+
+	// tx success stuff
+	icr &= ~(3);
+
+	// LINK STATUS CHANGE
+	if( icr & (1 << 2) )
+	{
+		icr &= ~(1 << 2);
+		mmio_write32(i825xx_REG_CTRL, (mmio_read32(i825xx_REG_CTRL) | CTRL_SLU));
+
+		// debugging info (probably not necessary in most scenarios)
+		printk("i825xx: Link Status Change, STATUS = 0x%x\n", mmio_read32(i825xx_REG_STATUS));
+		printk("i825xx: PHY CONTROL = 0x%x\n", net_i825xx_phy_read(dev, i825xx_PHYREG_PCTRL));
+		printk("i825xx: PHY STATUS = 0x%x\n", net_i825xx_phy_read(dev, i825xx_PHYREG_PSTATUS));
+		printk("i825xx: PHY PSSTAT = 0x%x\n", net_i825xx_phy_read(dev, i825xx_PHYREG_PSSTAT));
+		printk("i825xx: PHY ANA = 0x%x\n", net_i825xx_phy_read(dev, 4));
+		printk("i825xx: PHY ANE = 0x%x\n", net_i825xx_phy_read(dev, 6));
+		printk("i825xx: PHY GCON = 0x%x\n", net_i825xx_phy_read(dev, 9));
+		printk("i825xx: PHY GSTATUS = 0x%x\n", net_i825xx_phy_read(dev, 10));
+		printk("i825xx: PHY EPSTATUS = 0x%x\n", net_i825xx_phy_read(dev, 15));
+	}
+
+	// RX underrun / min threshold
+	if( icr & (1 << 6) || icr & (1 << 4) )
+	{
+		icr &= ~((1 << 6) | (1 << 4));
+		printk(" underrun (rx_head = %u, rx_tail = %u)\n", mmio_read32(i825xx_REG_RDH), dev->rx_tail);
+
+		volatile int i;
+		for(i = 0; i < NUM_RX_DESCRIPTORS; i++)
+		{
+			if( dev->rx_desc[i]->status )
+				printk(" pending descriptor (i=%u, status=0x%x)\n", i, dev->rx_desc[i]->status );
+		}
+
+		netdev->rx_poll(netdev);
+	}
+
+	// packet is pending
+	if( icr & (1 << 7) )
+	{
+		icr &= ~(1 << 7);
+		netdev->rx_poll(netdev);
+	}
+
+	if( icr )
+		printk("i825xx[%u]: unhandled interrupt #%u received! (0x%x)\n", netdev->hwid, ctx->vector, icr);
+
+	// clearing the pending interrupts
+	mmio_read32(dev->mmio_address + 0xC0);
+}
+
+/***************************************************
+ ** Intel 825xx-series Chipset Driver Entry Point **
+ ***************************************************/
+int net_i825xx_init( struct pci_device *pcidev )
+{
+	net_device_t *netdev = (net_device_t *)kmalloc(sizeof(net_device_t));
+	i825xx_device_t *dev = (i825xx_device_t *)kmalloc(sizeof(i825xx_device_t));
+
+	netdev->pci = pcidev;			// pci structure
+	netdev->lldev = (void *)dev;	// i825xx-specific structure
+	netdev->rx_count = netdev->tx_count = 0;
+	netdev->packets_dropped = 0;
+
+	// read the PCI BAR for the device's MMIO space
+	pci_bar *bar = pci_resolve_bar(pcidev, 0);
+
+	// is this BAR valid?
+	if( bar == NULL )
+		return -1;
+
+	// the spec says BAR0 is MMIO
+	if( bar->type != PCI_BAR_MMIO )
+		return -1;
+
+	// MMIO should not have this limitation for this chipset
+	if( bar->locate_below_1meg )
+		return -1;
+
+	// TODO (REMOVE) : DIAGNOSTIC INFO
+	printk("BAR0:\n");
+	printk(" type: %s\n", bar->type ? "I/O" : "Memory Mapped I/O");
+	printk(" prefetchable: %s\n", bar->prefetchable ? "true" : "false");
+	printk(" is64bit: %s\n", bar->is64bit ? "true" : "false");
+	printk(" locate below 1MB: %s\n", bar->locate_below_1meg ? "true" : "false");
+	printk(" address: 0x%x\n", bar->address);
+
+	// register the MMIO address
+	dev->mmio_address = (uintptr_t)bar->address;
+
+	// setup the function pointers
+	netdev->rx_init = net_i825xx_rx_init;
+	netdev->tx_init = net_i825xx_tx_init;
+	dev->eeprom_read = net_i825xx_eeprom_read;
+	netdev->rx_enable = net_i825xx_rx_enable;
+	netdev->rx_poll = net_i825xx_rx_poll;
+	netdev->tx_poll = net_i825xx_tx_poll;
+
+	// register the interrupt handler
+	netdev->interrupt_line = netdev->pci->interrupt_line;
+	AddInterruptServiceRoutine(netdev->interrupt_line, i825xx_interrupt_handler);
+
+	// globally register the devices
+	register_global_network_device( netdev );
+	printk("i825xx[%u]: interrupt line = %u (isr%u)\n", netdev->hwid, netdev->interrupt_line, 32+netdev->interrupt_line);
+
+	// get the MAC address
+	uint16_t mac16 = dev->eeprom_read(dev, 0);
+	netdev->mac_address[0] = (mac16 & 0xFF);
+	netdev->mac_address[1] = (mac16 >> 8) & 0xFF;
+	mac16 = dev->eeprom_read(dev, 1);
+	netdev->mac_address[2] = (mac16 & 0xFF);
+	netdev->mac_address[3] = (mac16 >> 8) & 0xFF;
+	mac16 = dev->eeprom_read(dev, 2);
+	netdev->mac_address[4] = (mac16 & 0xFF);
+	netdev->mac_address[5] = (mac16 >> 8) & 0xFF;
+
+	// set the LINK UP
+	mmio_write32(i825xx_REG_CTRL, (mmio_read32(i825xx_REG_CTRL) | CTRL_SLU));
+
+	// Initialize the Multicase Table Array
+	printk("i825xx[%u]: Initializing the Multicast Table Array...\n", netdev->hwid);
+	int i;
+	for( i = 0; i < 128; i++ )
+		mmio_write32(i825xx_REG_MTA + (i * 4), 0);
+
+	// enable all interrupts (and clear existing pending ones)
+	mmio_write32( i825xx_REG_IMS, 0x1F6DC );
+	mmio_read32(dev->mmio_address + 0xC0);
+
+	// start the RX/TX processes
+	netdev->rx_init(netdev);
+	netdev->tx_init(netdev);
+
+	printk("i825xx[%u]: configuration complete\n", netdev->hwid);
+
+	return 0;
+}

--- a/kernel/include/i825xx.h
+++ b/kernel/include/i825xx.h
@@ -1,0 +1,43 @@
+#ifndef NET_i825xx_H
+#define NET_i825xx_H
+
+#ifndef PCI_H
+	#include "pci.h"
+#endif
+
+#define i825xx_REG_CTRL			(dev->mmio_address + 0x0000)
+#define i825xx_REG_STATUS		(dev->mmio_address + 0x0008)
+#define i825xx_REG_EECD			(dev->mmio_address + 0x0010)
+#define i825xx_REG_EERD			(dev->mmio_address + 0x0014)
+
+#define i825xx_REG_MDIC			(dev->mmio_address + 0x0020)
+
+#define i825xx_REG_IMS			(dev->mmio_address + 0x00D0)
+#define i825xx_REG_RCTL			(dev->mmio_address + 0x0100)
+#define i825xx_REG_TCTL			(dev->mmio_address + 0x0400)
+
+#define i825xx_REG_RDBAL		(dev->mmio_address + 0x2800)
+#define i825xx_REG_RDBAH		(dev->mmio_address + 0x2804)
+#define i825xx_REG_RDLEN		(dev->mmio_address + 0x2808)
+#define i825xx_REG_RDH			(dev->mmio_address + 0x2810)
+#define i825xx_REG_RDT			(dev->mmio_address + 0x2818)
+
+#define i825xx_REG_TDBAL		(dev->mmio_address + 0x3800)
+#define i825xx_REG_TDBAH		(dev->mmio_address + 0x3804)
+#define i825xx_REG_TDLEN		(dev->mmio_address + 0x3808)
+#define i825xx_REG_TDH			(dev->mmio_address + 0x3810)
+#define i825xx_REG_TDT			(dev->mmio_address + 0x3818)
+
+#define i825xx_REG_MTA			(dev->mmio_address + 0x5200)
+
+#define i825xx_REG_RAL          (dev->mmio_address + 0x5400)
+#define i825xx_REG_RAH          (dev->mmio_address + 0x5404)
+
+// PHY REGISTERS (for use with the MDI/O Interface)
+#define i825xx_PHYREG_PCTRL		(0)
+#define i825xx_PHYREG_PSTATUS	(1)
+#define i825xx_PHYREG_PSSTAT	(17)
+
+int net_i825xx_init( struct pci_device * );
+
+#endif

--- a/kernel/include/pci.h
+++ b/kernel/include/pci.h
@@ -25,7 +25,7 @@ struct pci_device {
 	uint32_t sub_class;	  // sub class.
 	uint32_t base_class;     // base class.
 
-	// 0x0c 
+	// 0x0c
 	uint8_t header_type;     // header type.
 	uint8_t multi;           // multi device.
 
@@ -35,7 +35,21 @@ struct pci_device {
 
 	// 0x10-0x24
 	uint32_t base_address;   // base address.
+
+	//
+	uint16_t interrupt_line; // TODO: implement
 };
+
+// TODO: implement
+typedef struct pci_bar {
+	bool locate_below_1meg;
+	uint32_t address;
+	bool type;
+	bool prefetchable;
+	bool is64bit;
+} pci_bar;
+
+#define PCI_BAR_MMIO -1 // TODO: Set correct
 
 void find_pci_device(void);
 void show_all_pci_device(void);
@@ -46,4 +60,3 @@ uint32_t pci_data_read(struct pci_device *pci, uint8_t reg_num);
 
 
 #endif // __MIKOOS_PCI_H
-

--- a/kernel/include/pci.h
+++ b/kernel/include/pci.h
@@ -44,16 +44,17 @@ struct pci_device {
 typedef struct pci_bar {
 	bool locate_below_1meg;
 	uint32_t address;
-	bool type;
+	int type;
 	bool prefetchable;
 	bool is64bit;
 } pci_bar;
 
-#define PCI_BAR_MMIO -1 // TODO: Set correct
+#define PCI_BAR_MMIO 1 // TODO: Set correct
 
 void find_pci_device(void);
 void show_all_pci_device(void);
 struct pci_device *get_pci_device(uint16_t vender, uint16_t device, uint8_t function);
+struct pci_bar *pci_resolve_bar(struct pci_device *pci, int val);
 
 void pci_data_write(struct pci_device *pci, uint8_t reg_num, uint32_t data);
 uint32_t pci_data_read(struct pci_device *pci, uint8_t reg_num);

--- a/kernel/include/sys/types.h
+++ b/kernel/include/sys/types.h
@@ -16,6 +16,7 @@ typedef long                 int32_t;
 typedef unsigned long       uint32_t;
 typedef long long            int64_t;
 typedef unsigned long long  uint64_t;
+typedef unsigned int       uintptr_t;
 
 typedef int                  ssize_t;
 typedef uint32_t             size_t;

--- a/kernel/include/sys/types.h
+++ b/kernel/include/sys/types.h
@@ -16,7 +16,7 @@ typedef long                 int32_t;
 typedef unsigned long       uint32_t;
 typedef long long            int64_t;
 typedef unsigned long long  uint64_t;
-typedef unsigned int       uintptr_t;
+typedef unsigned int*      uintptr_t;
 
 typedef int                  ssize_t;
 typedef uint32_t             size_t;

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -21,6 +21,9 @@
 #include <io_port.h>
 #include <string.h>
 
+char buf0[512];
+char buf1[512];
+
 int kern_init(void)
 {
 	extern unsigned char syscall_handler;
@@ -88,17 +91,14 @@ int kern_init(void)
 	// Init ATA device.
 	init_ata_disk_driver();
 	show_all_registered_driver();
-	{
-		struct blk_device_drivers* drivers = get_blk_driver("ATA disk");
-		char buf0[512];
-		char buf1[512];
-		strcpy(buf1, "--------------- Please add virtual hard drive at primary master ------------ \n");
-		drivers->op->open();
-		strcpy(buf0, "--------------- Test data written in disk ----------------\n");
-		drivers->op->write(0, 100, (sector_t *)buf0, SECTOR_SIZE);
-		drivers->op->read(0, 100, (sector_t *)buf1, SECTOR_SIZE);
-		put_str(buf1);
-	}
+	struct blk_device_drivers* drivers = get_blk_driver("ATA disk");
+	drivers->op->open();
+	strcpy(buf1, "--------------- Please add virtual hard drive at primary master ------------\n");
+	strcpy(buf0, "--------------- Test data written in disk! Disk I/O Success ----------------\n");
+	drivers->op->write(0, 100, (sector_t *)buf0, SECTOR_SIZE);
+	drivers->op->read(0, 100, (sector_t *)buf1, SECTOR_SIZE);
+	put_str(buf1);
+
 	/* End of kernel initialization process */
 	while (1) {
 		x86_halt();
@@ -106,4 +106,3 @@ int kern_init(void)
 
 	return 0;
 }
-

--- a/kernel/memory.c
+++ b/kernel/memory.c
@@ -127,8 +127,9 @@ void* kmalloc(unsigned int size)
 	}
 
 	sTotalSize += size;
-	printk("kmalloc: %d left: %d\n", size, PAGE_SIZE-sTotalSize);
+	// printk("kmalloc: %d left: %d\n", size, PAGE_SIZE-sTotalSize);
 	if (sTotalSize > PAGE_SIZE)  {
+		printk("kmalloc: %d left: %d\n", size, PAGE_SIZE-sTotalSize);
 		KERN_ABORT("Too much memory");
 	}
 

--- a/kernel/pci.c
+++ b/kernel/pci.c
@@ -69,8 +69,8 @@ static inline uint32_t read_pci_class(struct pci_configuration_register *reg);
 static inline uint32_t read_pci_header_type(struct pci_configuration_register *reg);
 static uint32_t find_pci_data(uint8_t bus, uint8_t dev);
 
-static bool store_pci_device_to_list(uint8_t bus, uint8_t devfn, 
-				     uint32_t data, uint8_t func, 
+static bool store_pci_device_to_list(uint8_t bus, uint8_t devfn,
+				     uint32_t data, uint8_t func,
 				     uint32_t class, uint32_t header,
 				     uint32_t subsystem);
 
@@ -79,9 +79,9 @@ static inline int is_multi_function(uint32_t data)
 	return (data & 0x800000) ? 1 : 0;
 }
 
-static bool 
-store_pci_device_to_list(uint8_t bus, uint8_t devfn, 
-			 uint32_t data, uint8_t func, 
+static bool
+store_pci_device_to_list(uint8_t bus, uint8_t devfn,
+			 uint32_t data, uint8_t func,
 			 uint32_t class, uint32_t header,
 			 uint32_t subsystem)
 {
@@ -137,7 +137,7 @@ static uint32_t read_pci_data(struct pci_configuration_register *reg)
 
 	// write data to CONFIG_ADDRESS.
 	write_pci_config_address(reg);
-	
+
 	data = inl_p(CONFIG_DATA_1);
 
 	finish_access_to_config_data(reg);
@@ -158,7 +158,7 @@ static void write_pci_data(struct pci_configuration_register *reg, uint32_t data
 
 	// write data to CONFIG_ADDRESS.
 	write_pci_config_address(reg);
-	
+
 	outl_p(data, CONFIG_DATA_1);
 	finish_access_to_config_data(reg);
 }
@@ -173,13 +173,13 @@ static inline void write_pci_config_address(const struct pci_configuration_regis
 	uint32_t data = 0;
 
 	data = (reg->enable_bit << 31) |
-		(reg->reserved << 24) | 
-		(reg->bus_num << 16) | 
-		(reg->dev_num << 11) | 
+		(reg->reserved << 24) |
+		(reg->bus_num << 16) |
+		(reg->dev_num << 11) |
 		(reg->func_num << 8) |
 		reg->reg_num;
 
-	outl_p(data, PCI_CONFIG_ADDRESS);	
+	outl_p(data, PCI_CONFIG_ADDRESS);
 }
 
 /**
@@ -270,7 +270,7 @@ static uint32_t find_pci_data(uint8_t bus, uint8_t dev)
 
 	// Check all function numbers.
 	for (i = 0; i < PCI_FUNCTION_MAX; i++) {
-		reg.func_num = i;		
+		reg.func_num = i;
 		data = read_pci_reg00(&reg);
 		if (data != 0xffffffff) {
 
@@ -288,7 +288,7 @@ static uint32_t find_pci_data(uint8_t bus, uint8_t dev)
 				return 0;
 		}
 	}
-	
+
 	(void)status;
 
 	return 0;
@@ -310,7 +310,7 @@ static bool find_pci_bios32(void)
 	for (addr = 0xe0000; addr < 0xffff0; addr += 16) {
 		bios32 = (union pci_bios32 *) addr;
 
-		if (bios32 != NULL && 
+		if (bios32 != NULL &&
 		    bios32->fields.sig[0] == '_' &&
 		    bios32->fields.sig[1] == '3' &&
 		    bios32->fields.sig[2] == '2' &&
@@ -329,11 +329,11 @@ static bool find_pci_bios32(void)
 				}
 			}
 		}
-				
+
 	}
 	printk("pci bios32 not found\n");
 	return false;
- 
+
 }
 #endif // USE_PCI_BIOS32
 
@@ -364,9 +364,9 @@ void show_all_pci_device(void)
 	struct pci_device_list *p;
 
 	for (p = pci_device_head.next; p != &pci_device_head; p = p->next)
-		printk("Found Device: Bus %d:Devfn %d:Vender 0x%x:Device 0x%x:func %d:header 0x%x:Class 0x%lx-0x%lx:Multi %d\n", 
-		       p->data.bus, p->data.devfn, 
-		       p->data.vender, p->data.devid, 
+		printk("Found Device: Bus %d:Devfn %d:Vender 0x%x:Device 0x%x:func %d:header 0x%x:Class 0x%lx-0x%lx:Multi %d\n",
+		       p->data.bus, p->data.devfn,
+		       p->data.vender, p->data.devid,
 		       p->data.func, p->data.header_type,
 		       p->data.base_class, p->data.sub_class,
 		       p->data.multi);
@@ -390,6 +390,15 @@ struct pci_device *get_pci_device(uint16_t vender, uint16_t device, uint8_t func
 			return &p->data;
 	}
 
+	return NULL;
+}
+
+struct pci_bar *pci_resolve_bar(struct pci_device *pci, int val)
+{
+	// TODO: implement this
+	KERN_ABORT("not implemented");
+	(void)pci;
+	(void)val;
 	return NULL;
 }
 
@@ -429,7 +438,6 @@ void pci_data_write(struct pci_device *pci, uint8_t reg_num, uint32_t data)
 	reg.func_num = pci->func;
 	reg.dev_num = pci->devfn;
 	reg.bus_num = pci->bus;
-	
+
 	write_pci_data(&reg, data);
 }
-


### PR DESCRIPTION
add: i825xx.c. first add.
bugfix: memory corrupted by ata disk read on buf1. buf1 is moved to global.
